### PR TITLE
Fixed #56 -- Add constructor option to make editor persistent

### DIFF
--- a/docs/api/mjxgui-instance.md
+++ b/docs/api/mjxgui-instance.md
@@ -21,10 +21,11 @@ The MJXGUI constructor takes 1 required and 2 optional arguments -
 ## Options
 Currently, the following options are supported -
 
-| Option          | Data Type | Default value | Description                                                                                                                                                                             |
-|-----------------|-----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `mathDelimiter` | String    | `"$$"`        | The math delimiter as configured when you load MathJax. Use the same delimiter you use for inserting equation blocks, not inline equations. Most commonly used block delimiter is "$$". |
-| `theme`         | String    | `undefined`   | Pass theme as "dark" to render the MJXGUI widget in dark colors. Any other value will default to light mode.                                                                            |
+| Option          | Data Type | Default value | Description                                                                                                                                                                                                                                   |
+|-----------------|-----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mathDelimiter` | String    | `"$$"`        | The math delimiter as configured when you load MathJax. Use the same delimiter you use for inserting equation blocks, not inline equations. Most commonly used block delimiter is "$$".                                                       |
+| `theme`         | String    | `undefined`   | Pass theme as "dark" to render the MJXGUI widget in dark colors. Any other value will default to light mode.                                                                                                                                  |
+| `isPersistent`  | boolean   | `false`       | If `true`, the user-entered equation will not be deleted when the user clicks on the confirmation button and the success callback is run. Instead, the entered equation will persist and will be shown as is when the widget is opened again. |
 
 ## Writing A Success Callback
 The success callback you supply is run when the user is done entering an equation and clicks on the “✔” button. This is where you will be able to access the LaTeX for the entered equation, and handle it however you want. It is recommended to supply this function after creating an MJXGUI instance instead of passing it to the constructor, just because supplying it later lets you use both regular functions and arrow functions as the callback without having to worry about `this` in context.

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -129,6 +129,7 @@ class MJXGUI {
         this.elements = document.querySelectorAll(elementSelector);
         this.options = options;
         this.mathDelimiter = this.options.mathDelimiter || '$$';
+        this.isPersistent = options.isPersistent || false;
         this.successCallback = successCallback;
         this.eqnHistory = [];
         this.expression = new Expression();
@@ -288,7 +289,7 @@ class MJXGUI {
         saveEquationButton.addEventListener('click', () => {
             this.successCallback(this.getLatex(), this);
             this.hideUI();
-            this.clearEquation();
+            if (!this.isPersistent) this.clearEquation();
         });
 
         document.body.appendChild(editorDiv);
@@ -309,7 +310,11 @@ class MJXGUI {
         this.cursor.updateDisplay();
     }
 
-    // Getter method that just returns the cursor's LaTeX.
+    /**
+     * Getter method that returns the LaTeX for the currently built
+     * equation.
+     * @returns String - The generated LaTeX.
+     */
     getLatex() {
         return this.cursor.toLatex();
     }
@@ -391,6 +396,7 @@ class MJXGUI {
      * @param options An object of options for configuring the MJXGUI widget
      */
     static createEquationInput(selector, options = {}) {
+        if (options.isPersistent === undefined) options.isPersistent = true;
         const inputs = document.querySelectorAll(selector);
         const formInputHTML =
             '<div class="_mjxgui_equation_input"><button type="button" class="_mjxgui_insert_equation_button">Add Equation</button><div class="_mjxgui_equation_input_preview"></div></div>';


### PR DESCRIPTION
Fixed #56
Added an `isPersistent` option to the MJXGUI constructor which makes the editor widget persist the built equation when the user is done instead of clearing it.

Also made `isPersistent` `true` by default for editor widgets associated with HTML form inputs.